### PR TITLE
Add webpack npm script

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "bin/run",
     "sync_models": "node bin/sync_models.js",
-    "webpack": "./node_modules/.bin/webpack --config=webpack.config.js -d"
+    "webpack": "./node_modules/.bin/webpack --config=webpack.config.js -d --watch"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "start": "bin/run",
-    "sync_models": "node bin/sync_models.js"
+    "sync_models": "node bin/sync_models.js",
+    "webpack": "./node_modules/.bin/webpack --config=webpack.config.js -d"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Uses the `webpack` executable that's included with `npm install`, rather than the global one.  This has the benefit in that, if we run the web server on a machine that does not have `webpack` globally installed, it'll still be ok.

@david-zou 