### PR TITLE
Refactors 21 game engine internals

### DIFF
--- a/lib/TwentyOneGame/Engine.js
+++ b/lib/TwentyOneGame/Engine.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const Player = require('./Player');
+const { GameState, ActionTypes, EventTypes } = require('./GameState');
 
 const POWER_WORD_CARD = 'P';
 const CARD_VALUE_HIDDEN = '?';
@@ -14,7 +15,7 @@ class Engine {
     this.key = `21-game-${context}-${context_id}`;
 
     this.model = null;
-    this.model_data = {};
+    this.game_state = null;
   }
 
   /**
@@ -27,19 +28,16 @@ class Engine {
       .then(model => {
         if (model) {
           this.model = model;
-          this.model_data = JSON.parse(this.model.state) || {};
+
+          this.game_state = new GameState();
+          this.game_state.unserialize(this.model.state);
         } else {
-          this.model_data = {
-            key: this.key,
-            player_data: {},
-            deck: [],
-            game_started: false,
-          };
+          this.game_state = new GameState();
 
           return GenericGameState.create(
             {
               name: this.key,
-              state: JSON.stringify(this.model_data),
+              state: this.game_state.serialize(),
             }
           )
             .then(model => {
@@ -53,103 +51,51 @@ class Engine {
   }
 
   getPlayerIds() {
-    if (!this.model_data.player_data) {
-      return [];
-    }
-    return Object.keys(this.model_data.player_data);
+    return this.game_state.getPlayerIds();
   }
 
   getPlayer(player_id) {
-    if (this.model_data.player_data && this.model_data.player_data[player_id]) {
+    if (this.game_state.playerExists(player_id)) {
       return Promise.resolve(new Player(player_id, this));
     }
-    return Promise.reject(new Error(`You are not part of this game! The players are: [${this.getPlayerIds()}] [0007JPWQJD]`));
+    return Promise.reject(new Error(`You are not part of this game! The players are: [${this.game_state.getPlayerIds()}] [0007JPWQJD]`));
   }
 
   startGame() {
-    if (this.model_data.game_started) {
+    if (this.game_state.isGameStarted()) {
       return Promise.reject(new Error('The game has already started... [0004WQPWHFEW]'));
     }
 
-    this.model_data.game_started = true;
-    this.model_data.game_over = false;
-
-    // FIXME
-    // Shuffle the deck
-    this.model_data.deck = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11];
-    this.deckShuffle();
-
-    // select first player
-    let players = this.getPlayerIds();
-    this.model_data.player_turn = players[Math.floor(Math.random() * 2)];
-    this.model_data.player_acted = {};
-    players.forEach(id => {
-      // Ensure all players get one turn at least
-      this.model_data.player_acted[id] = true;
+    let events = this.game_state.dispatch({
+      type: ActionTypes.start_game,
     });
 
-    // Deal cards
-    let deal = this.dealInitialCards();
+    let deal = [];
+    events.forEach(event => {
+      if (event.type === EventTypes.receive_card) {
+        deal.push(event); // FIXME i guess...?
+      }
+    });
 
     return this.saveGame()
       .then(() => {
         return {
           players: this.getPlayerIds(),
-          deck_count: this.model_data.deck.length,
-          deal: deal,
+          deck_count: this.game_state.getDeck().length,
+          deal: deal, // FIXME figure out the deal from the events fired
         };
       });
-  }
-
-  /**
-   * Deals cards to each player; 1 face down and 1 face up.  Also converts
-   * any power words drawn.  Alters the players' hand states, and then
-   * returns all cards drawn in the order they were drawn and to which
-   * player they were dealt.
-   */
-  dealInitialCards() {
-    // Assertion: There are few enough players such that the entire deck is
-    // not dealt away on turn 0...
-
-    let player_ids = this.getPlayerIds();
-    let deal = [];
-
-    // Deal cards for all players, one face up and one hidden
-    player_ids.forEach(player_id => {
-      let card = this.dealPlayerCard(player_id, true);
-      deal.push(card);
-      card = this.dealPlayerCard(player_id, false);
-      deal.push(card);
-    });
-
-    return deal;
   }
 
   /**
    * Does not promise; also does not save the game!
    */
   dealPlayerCard(player_id, hidden = false) {
-    let card = this.deckNextCard();
-
-    // FIXME fuck power words
-    if (false && POWER_WORD_CARD === card) {
-      // Assumes only one power word per deck
-      this.model_data.player_data[player_id].power_words = this.model_data.player_data[player_id].power_words || [];
-      this.model_data.player_data[player_id].power_words.push(
-        {
-          word: '???',
-        }
-      );
-    }
-
-    // Add the card to the player's hand
-    this.model_data.player_data[player_id].hand = this.model_data.player_data[player_id].hand || [];
-    this.model_data.player_data[player_id].hand.push(
-      {
-        card: card,
-        hidden: hidden,
-      }
-    );
+    this.game_state.dispatch({
+      // Not quite but basically the same idea..
+      type: ActionTypes.player_hit,
+      player_id: player_id,
+    });
 
     return {
       card: card,
@@ -161,7 +107,7 @@ class Engine {
    * @returns {boolean}
    */
   isGameOver() {
-    return this.model_data.game_over;
+    return this.game_state.isGameOver();
   }
 
   /**
@@ -216,13 +162,19 @@ class Engine {
    * just drew.  End's the player's turn
    */
   playerHit(player) {
-    return this.playerAction(player)
-      .then(() => {
-        let card = this.dealPlayerCard(player.getId());
-        this.nextPlayerTurn(player);
-        return [card, this.saveGame()];
-      })
-      .spread((card, none) => card);
+    let events = this.game_state.dispatch({
+      type: ActionTypes.player_hit,
+      player_id: player.getId(),
+    });
+
+    let card = undefined;
+    events.forEach(event => {
+      if (event.type === EventTypes.receive_card) {
+        card = event.card;
+      }
+    });
+
+    return this.saveGame().then(() => card);
   }
 
   /**
@@ -231,7 +183,11 @@ class Engine {
    * End's the player's turn with no draw.  Returns the id of the next player.
    */
   playerStay(player) {
-    let next_player_id = this.nextPlayerTurn(player);
+    this.game_state.dispatch({
+      type: ActionTypes.player_stay,
+      player_id: player.getId(),
+    });
+    let next_player_id = 'TBD?';
     return this.saveGame()
       .then(() => {
         return next_player_id;
@@ -242,107 +198,41 @@ class Engine {
    * Synchronous
    */
   playerGetHand(player_id) {
-    return this.model_data.player_data[player_id].hand;
+    return this.game_state.getPlayerHand(player_id);
   }
-
-  /**
-   * Does not promise; also does not save the game!
-   */
-  nextPlayerTurn(player) {
-    if (player.getId() !== this.model_data.player_turn) {
-      throw new Error('It is not your turn!');
-    }
-
-    // Check if everybody has done nothing, if so mark the game as over
-    // So the client can stop rendering stuff
-    let ended = true;
-    this.getPlayerIds().forEach(player_id => {
-      if (this.model_data.player_acted[player_id]) {
-        ended = false;
-      }
-    });
-    if (ended) {
-      this.model_data.game_over = true;
-    }
-
-    // Select the next player
-    let current_player = player.getId();
-    let player_ids = this.getPlayerIds();
-    let index_of = player_ids.indexOf(current_player);
-    if (index_of >= player_ids.length - 1) {
-      index_of = 0;
-    } else {
-      // DAVID SAVE ME WTFFF
-      index_of += 1;
-    }
-    let next_player_id = player_ids[index_of];
-
-    // Move to the next player, and then set their "player acted" state to false
-    // and change it to true if they decide to do something
-    this.model_data.player_turn = next_player_id;
-    this.model_data.player_acted[next_player_id] = false;
-
-    return next_player_id;
-  }
-
-  /**
-   * Promise.  Doesn't actually have to do be but it's nice for syntactic sugar
-   *
-   * Sets the player action to true for this turn
-   */
-  playerAction(player) {
-    if (player.getId() !== this.model_data.player_turn) {
-      return Promise.reject(new Error('It is not your turn!'));
-    }
-    this.model_data.player_acted[player.getId()] = true;
-    return Promise.resolve(this);
-  }
-
-  /**
-   * Returns the top card of the deck and then removes it from the deck.
-   * Returns undefined if no cards left in the deck.
-   */
-  deckNextCard() {
-    return this.model_data.deck.shift();
-  }
-
-  deckShuffle() {
-    let pivot, swap1, swap2;
-    for (swap2 = this.model_data.deck.length; swap2; swap2--) {
-      pivot = Math.floor(Math.random() * swap2);
-      swap1 = this.model_data.deck[swap2-1];
-      this.model_data.deck[swap2-1] = this.model_data.deck[pivot];
-      this.model_data.deck[pivot] = swap1;
-    }
-  }
-
+  
   /**
    * @returns {Promise}
    */
   whosTurn() {
-    if (!this.model_data.game_started) {
+    if (!this.game_state.isGameStarted()) {
       return Promise.reject(new Error('The game has not yet started [0001ABFEURQWJ]'));
     }
-    return Promise.resolve(this.model_data.player_turn);
+    return Promise.resolve(this.game_state.whosTurn());
   }
 
   addPlayer(player) {
-    if (this.model_data.game_started) {
+    if (this.game_state.isGameStarted()) {
       return Promise.reject(new Error('The game has already started... [0017PMQCNWPW]'));
     }
-    this.model_data.player_data = this.model_data.player_data || {};
-    this.model_data.player_data[player.getId()] = {
+
+    this.game_state.dispatch({
+      type: ActionTypes.player_join,
       player_id: player.getId(),
-    };
+    });
 
     return this.saveGame().then(() => player);
   }
 
   removePlayer(player) {
-    if (this.model_data.game_started) {
+    if (this.game_state.isGameStarted()) {
       return Promise.reject(new Error('The game has already started... [0022QOQSMMPS]'));
     }
-    this.model_data.player_data[player.getId()] = undefined;
+
+    this.game_state.dispatch({
+      type: ActionTypes.player_leave,
+      player_id: player.getId(),
+    });
 
     return this.saveGame();
   }
@@ -353,7 +243,7 @@ class Engine {
    * Pushes this.model_data and this.model to the database
    */
   saveGame() {
-    this.model.state = JSON.stringify(this.model_data);
+    this.model.state = this.game_state.serialize();
     return this.model.save();
   }
 }

--- a/lib/TwentyOneGame/Engine.js
+++ b/lib/TwentyOneGame/Engine.js
@@ -81,6 +81,11 @@ class Engine {
     // select first player
     let players = this.getPlayerIds();
     this.model_data.player_turn = players[Math.floor(Math.random() * 2)];
+    this.model_data.player_acted = {};
+    players.forEach(id => {
+      // Ensure all players get one turn at least
+      this.model_data.player_acted[id] = true;
+    });
 
     // Deal cards
     let deal = this.dealInitialCards();
@@ -251,7 +256,7 @@ class Engine {
     // So the client can stop rendering stuff
     let ended = true;
     this.getPlayerIds().forEach(player_id => {
-      if (this.model_data.player_data[player_id].player_acted) {
+      if (this.model_data.player_acted[player_id]) {
         ended = false;
       }
     });
@@ -274,7 +279,6 @@ class Engine {
     // and change it to true if they decide to do something
     let next_player_id = player_ids[index_of];
     this.model_data.player_turn = next_player_id;
-    this.model_data.player_acted = this.model_data.player_acted || {};
     this.model_data.player_acted[next_player_id] = false;
 
     return next_player_id;
@@ -289,7 +293,6 @@ class Engine {
     if (player.getId() !== this.model_data.player_turn) {
       return Promise.reject(new Error('It is not your turn!'));
     }
-    this.model_data.player_acted = this.model_data.player_acted || {};
     this.model_data.player_acted[player.getId()] = true;
     return Promise.resolve(this);
   }

--- a/lib/TwentyOneGame/Engine.js
+++ b/lib/TwentyOneGame/Engine.js
@@ -72,6 +72,7 @@ class Engine {
     }
 
     this.model_data.game_started = true;
+    this.model_data.game_over = false;
 
     // FIXME
     // Shuffle the deck
@@ -264,7 +265,7 @@ class Engine {
       this.model_data.game_over = true;
     }
 
-    //
+    // Select the next player
     let current_player = player.getId();
     let player_ids = this.getPlayerIds();
     let index_of = player_ids.indexOf(current_player);
@@ -274,10 +275,10 @@ class Engine {
       // DAVID SAVE ME WTFFF
       index_of += 1;
     }
+    let next_player_id = player_ids[index_of];
 
     // Move to the next player, and then set their "player acted" state to false
     // and change it to true if they decide to do something
-    let next_player_id = player_ids[index_of];
     this.model_data.player_turn = next_player_id;
     this.model_data.player_acted[next_player_id] = false;
 

--- a/lib/TwentyOneGame/Engine.js
+++ b/lib/TwentyOneGame/Engine.js
@@ -200,7 +200,7 @@ class Engine {
   playerGetHand(player_id) {
     return this.game_state.getPlayerHand(player_id);
   }
-  
+
   /**
    * @returns {Promise}
    */

--- a/lib/TwentyOneGame/Errors.js
+++ b/lib/TwentyOneGame/Errors.js
@@ -1,0 +1,6 @@
+'use strict';
+
+
+module.exports = {
+
+};

--- a/lib/TwentyOneGame/Game.js
+++ b/lib/TwentyOneGame/Game.js
@@ -31,10 +31,14 @@ class Game {
    * @returns {Promise}
    */
   debugSetGameState(state) {
-    return this.getEngine().then(engine => {
-      engine.model_data = state;
-      return engine.saveGame();
-    });
+    return this.getEngine()
+      .then(engine => {
+        engine.model_data = state;
+        return engine.saveGame();
+      })
+      .then(() => {
+        return this;
+      });
   }
 
   /**

--- a/lib/TwentyOneGame/Game.js
+++ b/lib/TwentyOneGame/Game.js
@@ -3,6 +3,7 @@
 const Engine = require('./Engine');
 const Player = require('./Player');
 const Output = require('./Output');
+const { GameState } = require('./GameState');
 
 /**
  * The game is a facade that exposes only methods that directly face the rest of the application code.
@@ -23,7 +24,7 @@ class Game {
    */
   debugGetGameState() {
     return this.getEngine().then(engine => {
-      return engine.model_data;
+      return engine.game_state;
     });
   }
 
@@ -33,7 +34,8 @@ class Game {
   debugSetGameState(state) {
     return this.getEngine()
       .then(engine => {
-        engine.model_data = state;
+        engine.game_state = new GameState();
+        engine.game_state.unserialize(JSON.stringify(state)); // FIXME i guess?
         return engine.saveGame();
       })
       .then(() => {

--- a/lib/TwentyOneGame/GameState.js
+++ b/lib/TwentyOneGame/GameState.js
@@ -1,62 +1,333 @@
 'use strict';
 
 /**
- * @deprecated
+ * A stateful, synchronous, dependency-less container for all of the game's state.
+ * Persistence does not belong here.
+ *
+ * This gamestate should not be modified directly; instead, it provides a suite of
+ * all possible state transitions.
  */
 class GameState {
   /**
    *
    */
   constructor() {
-    // One game per channel
-    this.channel_id = null;
+    // A unique identifier for this gamestate.  Every unique game has a different key.
+    this.key = null;
 
-    // Associative arrays keyed by the player id, mapped to individual player data, which are dicts
-    // with the following keys:
-    //   foreign_id =
+    // A map of player_id => individual player state.
+    //
+    //   The player's state has:
+    //     -
     this.player_data = {};
 
-    //
+    // The deck, ordered from topmost to bottom most
     this.deck = [];
 
-    // Wild Cards
-    this.wild_cards = [];
+    // True when the game is in session, false otherwise
+    this.game_started = false;
+
+    // True when an in-session game is over.
+    this.game_over = false;
+
+    // Maps player_ids to their most recent action(s)
+    this.player_acted = {};
+
+    // The player_id whose turn it is
+    this.player_turn = null;
+
+    // A historic log of everything that happened during the game
+    this.events = [];
   }
 
-  /**
-   * Promisified
-   *
-   * Returns the current GameState object, initialized
-   */
-  load(channel_id) {
-    this.channel_id = channel_id;
+  setKey(key) {
+    this.key = key;
   }
 
-  initialize(channel_id) {
-
+  isGameStarted() {
+    return this.game_started;
   }
 
   getPlayerIds() {
     return Object.keys(this.player_data);
   }
 
-  getPlayerData(player_id) {
-    return this.player_data[player_id];
+  playerExists(player_id) {
+    return !!this.player_data[player_id];
   }
 
-  addPlayer(player) {
-    this.player_data[player.getId()] = {
-      player_id: player.getId(),
-    };
+  getDeck() {
+    return this.deck;
   }
 
-  setPlayerData(player_id, key) {
-
+  isGameOver() {
+    return this.game_over;
   }
 
-  getPlayerRemainingLife(player_id) {
-    return -1;
+  allPlayersStayed() {
+    let stayed = true;
+    this.getPlayerIds().forEach(player_id => {
+      if (this.player_acted[player_id]) {
+        stayed = false;
+      }
+    });
+    return stayed;
+  }
+
+  getPlayerHand(player_id) {
+    return this.player_data[player_id].hand;
+  }
+
+  isPlayerTurn(player_id) {
+    return player_id === this.player_turn;
+  }
+
+  whosTurn() {
+    return this.player_turn;
+  }
+
+  unserialize(serialized_state) {
+    let data = JSON.parse(serialized_state);
+
+    this.key = data.key || '';
+    this.player_data = data.player_data || {};
+    this.deck = data.deck || [];
+    this.game_started = data.game_started || false;
+    this.game_over = data.game_over || false;
+    this.player_acted = data.player_acted || {};
+    this.player_turn = data.player_turn || null;
+    this.events = data.events || [];
+  }
+
+  serialize() {
+    return JSON.stringify(
+      {
+        key: this.key,
+        player_data: this.player_data,
+        deck: this.deck,
+        game_started: this.game_started,
+        game_over: this.game_over,
+        player_acted: this.player_acted,
+        player_turn: this.player_turn,
+        events: this.events,
+      }
+    );
+  }
+
+  /**
+   * Fires an action, modifying the game state appropriately via the
+   * configured reducers.
+   *
+   * Actions always result in new events being recorded in the game state event
+   * log.  The return value of the dispatch call are all NEW events generated
+   * by this action.
+   */
+  dispatch(action) {
+    // FIXME hack in the design
+    let last_event_index = this.events.length;
+    reducerStack.forEach(reducer => {
+      reducer(this, action);
+    });
+    // Now we slice off all the events after the reducers are applied to find the new ones
+    return this.events.slice(last_event_index);
   }
 }
 
-module.exports = GameState;
+const reducerStack = [
+  actionRecordingReducer,
+  gameInitializationReducer,
+  playerManagementReducer,
+  playerPlayReducer,
+  playerActedReducer,
+  endGameReducer,
+  nextPlayerTurnReducer,
+];
+
+/**
+ * This reducer does nothing more than record all actions that occur
+ * mostly for debugging purposes
+ */
+function actionRecordingReducer(game_state, action) {
+  game_state.events.push(action);
+}
+
+/**
+ * This reducer fires during game starting events
+ */
+function gameInitializationReducer(game_state, action) {
+  switch (action.type) {
+    case ActionTypes.start_game:
+      if (game_state.game_started) {
+        // Nothing
+        return;
+      }
+      game_state.game_started = true;
+      game_state.game_over = true;
+      game_state.deck = shuffle([1,2,3,4,5,6,7,8,9,10,11]);
+
+      let players = game_state.getPlayerIds();
+      game_state.player_turn = players[Math.floor(Math.random() * 2)];
+      game_state.player_acted = {};
+      players.forEach(id => game_state.player_acted[id] = true);
+
+      players.forEach(id => {
+        dealPlayerCard(game_state, id, true);
+        dealPlayerCard(game_state, id, false);
+      });
+
+      game_state.events.push({
+        type: EventTypes.game_initialized
+      });
+
+      break;
+  }
+
+  function shuffle(deck) {
+    let pivot, swap1, swap2;
+    for (swap2 = deck.length; swap2; swap2--) {
+      // I have no fuckin clue what this algorithm does I found it on stack overflow
+      pivot = Math.floor(Math.random() * swap2);
+      swap1 = deck[swap2-1];
+      deck[swap2-1] = deck[pivot];
+      deck[pivot] = swap1;
+    }
+    return deck;
+  }
+}
+
+function playerManagementReducer(game_state, action) {
+  if (game_state.game_started) {
+    // Do nothing; you can't join or leave once the game starts
+    return;
+  }
+  switch (action.type) {
+    case ActionTypes.player_join:
+      game_state.player_data[action.player_id] = {
+        player_id: action.player_id,
+      };
+      break;
+    case ActionTypes.player_leave:
+      game_state.player_data[action.player_id] = undefined;
+      break;
+  }
+}
+
+function playerPlayReducer(game_state, action) {
+  if (!game_state.game_started) {
+    // Can't play when not started
+    return;
+  }
+  switch (action.type) {
+    case ActionTypes.player_hit:
+      dealPlayerCard(game_state, action.player_id, false);
+      break;
+    case ActionTypes.player_stay:
+      break;
+  }
+}
+
+function playerActedReducer(game_state, action) {
+  if (!game_state.game_started) {
+    return;
+  }
+  switch (action.type) {
+    // FIXME Power words go here too
+    case ActionTypes.player_hit:
+      game_state.player_acted[action.player_id] = true;
+      break;
+    case ActionTypes.player_stay:
+      // Do nothing; because they may have played a non-turn-ending power word
+      break;
+  }
+}
+
+/**
+ * Flips the game_over flag and fires the game end event
+ */
+function endGameReducer(game_state, action) {
+  switch (action.type) {
+    case ActionTypes.player_hit: // Even though this is turn-ending, it is impossible to trigger a game end
+    case ActionTypes.player_stay:
+      if (game_state.allPlayersStayed()) {
+        game_state.game_over = true;
+        game_state.events.push({
+          type: EventTypes.game_ended
+        })
+      }
+      break;
+  }
+}
+
+/**
+ * This reducer figures out whos turn it is next
+ */
+function nextPlayerTurnReducer(game_state, action) {
+  if (!game_state.game_started) {
+    return;
+  }
+
+  switch (action.type) {
+    case ActionTypes.player_hit:
+    case ActionTypes.player_stay:
+      let current_player = game_state.player_turn;
+      let player_ids = game_state.getPlayerIds();
+      let index_of = player_ids.indexOf(current_player);
+
+      // Move forward by 1 unless you're at the end of the array, otherwise go back to 0
+      if (index_of >= player_ids.length - 1) {
+        index_of = 0;
+      } else {
+        // DAVID SAVE ME WTFFF
+        index_of += 1;
+      }
+      let next_player_id = player_ids[index_of];
+
+      // Move to the next player, and then set their "player acted" state to false
+      // and change it to true if they decide to do something
+      game_state.player_turn = next_player_id;
+      game_state.player_acted[next_player_id] = false;
+      break;
+  }
+}
+
+
+function dealPlayerCard(game_state, player_id, hidden = false) {
+  let card = game_state.deck.shift();
+
+  // Add the card to the player's hand
+  game_state.player_data[player_id].hand = game_state.player_data[player_id].hand || [];
+  game_state.player_data[player_id].hand.push(
+    {
+      card: card,
+      hidden: hidden,
+    }
+  );
+
+  game_state.events.push({
+    type: EventTypes.receive_card,
+    player: player_id,
+    card: card,
+    hidden: hidden,
+  });
+}
+
+const ActionTypes = {
+  player_join: 'player_join',
+  player_leave: 'player_leave',
+  player_hit: 'player_hit',
+  player_stay: 'player_stay',
+  start_game: 'start_game',
+};
+
+const EventTypes = {
+  game_started: 'game_started',
+  receive_card: 'receive_card',
+  game_initialized: 'game_initialized',
+  game_ended: 'game_ended',
+};
+
+module.exports = {
+  GameState,
+  ActionTypes,
+  EventTypes,
+};

--- a/lib/TwentyOneGame/Player.js
+++ b/lib/TwentyOneGame/Player.js
@@ -103,7 +103,7 @@ class Player {
    */
   gameInfo(show_hidden = false) {
     //FIXME this is just extracting shit because proof of concept
-    let GAMEDATA = this.engine.model_data;
+    let game_state = this.engine.game_state;
 
     let player_ids = this.engine.getPlayerIds();
     let first_player = this.getId();
@@ -134,11 +134,11 @@ Player <@${player_id}>
     };
 
     let player_info_strings = '';
-    player_info_strings += renderPlayer(first_player, GAMEDATA.player_data[first_player].hand);
+    player_info_strings += renderPlayer(first_player, game_state.getPlayerHand(first_player));
     rest_players.forEach(player_id => {
-      player_info_strings += renderPlayer(player_id, GAMEDATA.player_data[player_id].hand);
+      player_info_strings += renderPlayer(player_id, game_state.getPlayerHand(first_player));
     });
-    let deck_string = 'Deck: ' + '[ ]'.repeat(GAMEDATA.deck.length);
+    let deck_string = 'Deck: ' + '[ ]'.repeat(game_state.getDeck().length);
 
     this.output.send(
 `
@@ -162,7 +162,7 @@ ${deck_string}
         return this.engine.playerHit(this);
       })
       .then(card => {
-        this.output.send(`You drew a ${card.card}!`);
+        this.output.send(`You drew a ${card}!`);
       })
       .delay(500)
       .then(() => {

--- a/test/TwentyOneGameTest.js
+++ b/test/TwentyOneGameTest.js
@@ -156,7 +156,8 @@ describe('21 Game Setup', function () {
         },
         deck: [ 5, 6, 7, 8, 9, 10, 11 ],
         game_started: true,
-        player_acted: { 'xyz2': true, 'abc1': true },
+        game_over: false,
+        player_acted: { 'xyz2': false, 'abc1': true },
         player_turn: 'xyz2' })
       .then((game) => game)
       .then(game => {
@@ -215,6 +216,9 @@ describe('21 Game Setup', function () {
           {card: 5, hidden: false},
         ], p2_hand);
 
+        // Player 2 did something
+        assert.ok(game_state.player_acted['xyz2']);
+
         // And it should now be player1's turn
         assert.equal('abc1', game_state.player_turn);
       });
@@ -248,10 +252,35 @@ describe('21 Game Setup', function () {
         ], p2_hand);
 
         // Also mark that player2 did not do anything
-        assert.ok(game_state.player_acted['xyz2']);
+        assert.ok(!game_state.player_acted['xyz2']);
 
         // And it should now be player1's turn
         assert.equal('abc1', game_state.player_turn);
+      });
+  });
+
+  it('double pass should end game', function () {
+    let value = '';
+    const capture = function(message) { value += message + '\n'; };
+
+    let stored_game;
+    let player1, player2;
+    return newStartedGame(capture)
+      .spread((game, p1, p2) => {
+        player1 = p1;
+        player2 = p2;
+        stored_game = game;
+      })
+      .then(() => player2.stay())
+      .then(() => player1.stay())
+      .then(() => stored_game.debugGetGameState())
+      .then(game_state => {
+        // Also mark that both player1 and player2 did not do anything
+        assert.ok(!game_state.player_acted['abc1']);
+        assert.ok(!game_state.player_acted['xyz2']);
+
+        // It's game over now
+        assert.ok(game_state.game_over);
       });
   });
 


### PR DESCRIPTION
# Big Idea
-----

I've found that the `!21` game was getting rather difficult to maintain due to the coupling the game's representation, persistence, and game rules.

## Originally...
My original intent was to separate the game's presentation (aka, what people see) from the guts.  `Player` would be the game's abstract representation of an actor, which interfaces with the `Engine`, the guts.  Then, each player could be instantiated with its own presentation (e.g. Slack chat connection, or React page, etc).  Obviously, my attempt was only partially successful, as I started to throw Slack-specific garbage into `Player`.  That, however, ultimately was not the problem.

## THE PROBLEM
Let's approach the game with several concepts in mind:

* State representation, management, and transition (aka, how many cards in the deck, what are the cards in each players' hands, which power words are in play?)
* State persistence (how is **_state_** saved to a database, how is it loaded?)
* Game Rules (what happens when you draw a card, when does the game end, did you win, what happens when you play a power word?)
* Game Presentation (What does it look like in the UI whenever you play stuff, when you load the game, what does chuubot say to you, what React components exist?)

In typical **_Model-View-Controller_** fashion, what I typically do is start by separating out the `View` part first (aka chuubot, in our case) and smashing `Model+Controller` together.  Typically, it's easier to decouple `Model+Controller` than `View+Model`

WELL, IN ECMASCRIPT ITS DIFFERENT.  Due to the asynchronous nature of code, once you have one asynchronous operation, **everything that calls it must become asynchronous too**.  In my case, all calls to Sequelize are async (Promisified).  Because every call requires you to save to the database, this causes all of our code to become this **tangled up mess of fucking `.then` and `.spread` and `() => {}` shit**.  The code is hard to understand and hard to write.

## The Solution
Well, a partial (but so far very effective) solution.  The idea here is to separate these concepts:

* State representation, management, and transition

Entirely from State persistence.  This allows all State persistence code to continue to be async, but all state representation/management/transition code can be made synchronous.  Additionally, I adopted `redux`'s pattern using `Actions`+`Reducers` for state management.  You can see a lot of the code splattered [here](https://github.com/Ryxias/react-hell/blob/35e1be7ed09961dcbac2e3191ea1da27d936d12c/lib/TwentyOneGame/GameState.js). 

The aspiration here is to **_keep synchronous code synchronous_** and **_separate state management from its persistence_**.  Additionally, with the new `Action`+`Reducer`+`Event` model, I'm hoping that writing unit tests will be ever the easier as well.

@david-zou PTAL
Let me know if you have any questions