### PR TITLE
Site Development/Testing Environment Setup for Local

### DIFF
--- a/bin/deploy-nico
+++ b/bin/deploy-nico
@@ -9,4 +9,4 @@ set -e
 REMOTEUSER=nico
 
 # Use rsync to bring all files from this project
-rsync -avr --progress ~/Documents/OneDrive/Projects/react-hell/. $REMOTEUSER@machine.chuuni.me:~/repos/react-hell --exclude .git --exclude .idea --exclude /node_modules
+rsync -avr --progress ~/github/react-hell/. $REMOTEUSER@machine.chuuni.me:~/repos/react-hell --exclude .git --exclude .idea --exclude /node_modules

--- a/configuration_loader.js
+++ b/configuration_loader.js
@@ -4,7 +4,7 @@
 //   which should be a javascript file that exports 'config'
 //
 
-const CONFIG_FILE_PATH = '/etc/chuuni/config';
+const CONFIG_FILE_PATH = process.env.NODE_ENV === 'production' ? '/etc/chuuni/config' : './config/config';
 
 // Blows up on bad permissions
 const config = require(CONFIG_FILE_PATH);

--- a/init/ExpressApplication.js
+++ b/init/ExpressApplication.js
@@ -15,6 +15,9 @@ class ExpressApplication extends require('./BaseApplication') {
   }
 
   appBoot() {
+    // check environment
+    const PRODUCTION = process.env.NODE_ENV === 'production';
+
     // include packages
     const express = this.loadPackage('express');
 
@@ -33,21 +36,25 @@ class ExpressApplication extends require('./BaseApplication') {
     const app = express();
 
     // View Engine
-    app.engine('handlebars', this.loadPackage('express-handlebars')({ defaultLayout: 'base' }));
-    app.set('view engine', 'handlebars');
+    // app.engine('handlebars', this.loadPackage('express-handlebars')({ defaultLayout: 'base' }));
+    // app.set('view engine', 'handlebars');
 
     // Attach middleware
-    app.use(redirectHttpToHttps);
+    if (PRODUCTION) {
+      app.use(redirectHttpToHttps);
+    }
     app.use('/statics', staticsMiddleware);
     app.use(appRouter);
     app.use(notFoundHandler);
     app.use(defaultErrorHandler);
 
     // Connect chuubot
-    chuubot.connect();
+    if (PRODUCTION) {
+      chuubot.connect();
+    }
 
     const runServer = () => {
-      const port = 80;
+      const port = PRODUCTION ? 80 : 8000;
 
       // We only listen to port 80
       //   On AWS, the application is fronted by a load balancer which terminates all inbound connections

--- a/init/ExpressApplication.js
+++ b/init/ExpressApplication.js
@@ -16,7 +16,7 @@ class ExpressApplication extends require('./BaseApplication') {
 
   appBoot() {
     // check environment
-    const PRODUCTION = process.env.NODE_ENV === 'production';
+    const production = process.env.NODE_ENV === 'production';
 
     // include packages
     const express = this.loadPackage('express');
@@ -35,12 +35,8 @@ class ExpressApplication extends require('./BaseApplication') {
     // Initialize the express app
     const app = express();
 
-    // View Engine
-    // app.engine('handlebars', this.loadPackage('express-handlebars')({ defaultLayout: 'base' }));
-    // app.set('view engine', 'handlebars');
-
     // Attach middleware
-    if (PRODUCTION) {
+    if (production) {
       app.use(redirectHttpToHttps);
     }
     app.use('/statics', staticsMiddleware);
@@ -49,12 +45,12 @@ class ExpressApplication extends require('./BaseApplication') {
     app.use(defaultErrorHandler);
 
     // Connect chuubot
-    if (PRODUCTION) {
+    if (production) {
       chuubot.connect();
     }
 
     const runServer = () => {
-      const port = PRODUCTION ? 80 : 8000;
+      const port = production ? 80 : this.config.port;
 
       // We only listen to port 80
       //   On AWS, the application is fronted by a load balancer which terminates all inbound connections

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Me learning the hell hole that is react",
   "main": "index.js",
   "scripts": {
-    "start": "sudo nodemon server/server.js",
+    "start": "sudo NODE_ENV=production nodemon server/server.js",
+    "dev": "sudo NODE_ENV=development nodemon server/server.js",
     "sync_models": "node bin/sync_models.js",
     "webpack": "./node_modules/.bin/webpack --config=webpack.config.js -d --watch",
     "test": "./node_modules/mocha/bin/mocha"


### PR DESCRIPTION
[10/6/2017]
Changes Made:
1) Made changes to configuration loader, ExpressApplication and package.json scripts to allow testing/development under the local machine instead of production environment.
2) Changed the deployment script for 'nico' to point to the new project directory

Possible Impact(s):
Certain middleware in the Express application will be determined whether it will be run or not based on the global NODE_ENV environment variable that is set during the starting of the Node server (`npm start` for production vs. `npm run dev` for development/testing).  For the time being, this test environment only works for development of the React site, but not the Slackbot, which will be tackled later.  This new code shouldn't affect production as long as `npm start` is ran on the EC2 instance and the appropriate configurations in `/etc/chuuni/config` and middleware should still run.

Rollback:
Revert to previous commit.  It should not affect anything on the database, so tables do not need to be dropped.

Reference:
https://github.com/Ryxias/react-hell/issues/47
http://www.hacksparrow.com/running-express-js-in-production-mode.html